### PR TITLE
Inconsistent Sidebar Styles - Fixed #1

### DIFF
--- a/publify_core/app/assets/stylesheets/administration_structure.css.scss
+++ b/publify_core/app/assets/stylesheets/administration_structure.css.scss
@@ -235,5 +235,5 @@ twitter-typeahead {
 
 .tt-hint {
   z-index: -1;
-  
+
 }

--- a/publify_core/app/assets/stylesheets/administration_structure.css.scss
+++ b/publify_core/app/assets/stylesheets/administration_structure.css.scss
@@ -235,5 +235,4 @@ twitter-typeahead {
 
 .tt-hint {
   z-index: -1;
-
 }

--- a/publify_core/app/assets/stylesheets/administration_structure.css.scss
+++ b/publify_core/app/assets/stylesheets/administration_structure.css.scss
@@ -235,5 +235,4 @@ twitter-typeahead {
 
 .tt-hint {
   z-index: -1;
-  
 }

--- a/publify_core/app/views/archives_sidebar/_content.html.erb
+++ b/publify_core/app/views/archives_sidebar/_content.html.erb
@@ -1,6 +1,6 @@
 <% unless sidebar.archives.blank? %>
-  <h3 class="sidebar_title"><%= sidebar.title %></h3>
-  <div class="sidebar_body">
+  <h3 class="sidebar-title"><%= sidebar.title %></h3>
+  <div class="sidebar-body">
     <ul id="archives">
       <% sidebar.archives.each do |month| %>
         <% counter = sidebar.show_count ? "<em>(#{month[:article_count]})</em>" : "" %>

--- a/themes/bootstrap-2/stylesheets/style.css
+++ b/themes/bootstrap-2/stylesheets/style.css
@@ -76,8 +76,12 @@ body {
 
 #sidebar {
   padding-top: 24px;
-  font-family: monospace
+
 }
-li {
+#sidebar .sidebar-title {
+  font-family: monospace;
+ }
+
+ #sidebar .sidebar-body li {
   list-style-type: circle;
 }

--- a/themes/bootstrap-2/stylesheets/style.css
+++ b/themes/bootstrap-2/stylesheets/style.css
@@ -76,12 +76,12 @@ body {
 
 #sidebar {
   padding-top: 24px;
-}
 
+}
 #sidebar .sidebar-title {
   font-family: monospace;
-}
+ }
 
-#sidebar .sidebar-body li {
+ #sidebar .sidebar-body li {
   list-style-type: circle;
 }

--- a/themes/bootstrap-2/stylesheets/style.css
+++ b/themes/bootstrap-2/stylesheets/style.css
@@ -76,12 +76,8 @@ body {
 
 #sidebar {
   padding-top: 24px;
+  font-family: monospace
 }
-
-#sidebar .sidebar-title {
-  font-family: monospace;
-}
-
-#sidebar .sidebar-body li {
+li {
   list-style-type: circle;
 }


### PR DESCRIPTION
Inconsistent Sidebar Styles - Fixed #1

Task / Request:
1. All titles in the sidebar should have monospace style font
2. All bullets should be unfilled circles.

Fixing the sidebar required setting the correct font to monostyle and setting the list (bullet points in the list) to circle which means that the bullets are not filled in circles (rather empty circles).

Changes were made to the bootstrap theme file.