### PR TITLE
fixed inconsistent sidebar styles problem

### DIFF
--- a/publify_core/app/views/archives_sidebar/_content.html.erb
+++ b/publify_core/app/views/archives_sidebar/_content.html.erb
@@ -1,6 +1,6 @@
 <% unless sidebar.archives.blank? %>
-  <h3 class="sidebar_title"><%= sidebar.title %></h3>
-  <div class="sidebar_body">
+  <h3 class="sidebar-title"><%= sidebar.title %></h3>
+  <div class="sidebar-body">
     <ul id="archives">
       <% sidebar.archives.each do |month| %>
         <% counter = sidebar.show_count ? "<em>(#{month[:article_count]})</em>" : "" %>


### PR DESCRIPTION
This pull request addresses the "Inconsistent Sidebar Styles" problem:
  https://github.com/sf-wdi-40/publify-debugging-lab/issues/1

Root Cause:
  The classes used by the sidebar archives are: "sidebar_title" and "sidebar_body", which are different from what other titles that use: "sidebar-title" and "sidebar-body".

Solution:
 Change the classes used by Archive to "sidebar-title" & "sidebar-body" like the rest.
