### PR TITLE
Inconsistent Sidebar Styles - Fixed #1

### DIFF
--- a/publify_core/app/views/archives_sidebar/_content.html.erb
+++ b/publify_core/app/views/archives_sidebar/_content.html.erb
@@ -1,6 +1,6 @@
 <% unless sidebar.archives.blank? %>
-  <h3 class="sidebar_title"><%= sidebar.title %></h3>
-  <div class="sidebar_body">
+  <h3 class="sidebar-title"><%= sidebar.title %></h3>
+  <div class="sidebar-body">
     <ul id="archives">
       <% sidebar.archives.each do |month| %>
         <% counter = sidebar.show_count ? "<em>(#{month[:article_count]})</em>" : "" %>


### PR DESCRIPTION
Inconsistent Sidebar Styles - Fixed #1

Task / Request:

All titles in the sidebar should have monospace style font
All bullets should be unfilled circles.
Fixing the sidebar required setting the correct font to monostyle and setting the list (bullet points in the list) to circle which means that the bullets are not filled in circles (rather empty circles).

Changes were made to the bootstrap theme file.