### PR TITLE
Post tags are shown as "object" #2

### DIFF
--- a/publify_core/app/assets/javascripts/publify_admin.js
+++ b/publify_core/app/assets/javascripts/publify_admin.js
@@ -76,7 +76,7 @@ function tag_manager() {
 }
 
 function save_article_tags() {
-  $('#article_keywords').val($('#article_form').find('input[name="hidden-article[keywords]"]'));
+  $('#article_keywords').val($('#article_form').find('input[name="hidden-article[keywords]"]').val());
 }
 
 function doneTyping () {


### PR DESCRIPTION
Post tags are shown as "object" #2 

What is the issue: After creating a post one can see that the posts tags, regardless of what was entered, are shown as "object".

What we want: the tags are displayed properly.

What we did: missing .val() at the end of the hidden input which was causing us to pass back an object and not the value.