### PR TITLE
Load spinner does not go away #3

### DIFF
--- a/publify_core/app/assets/javascripts/spinnable.js
+++ b/publify_core/app/assets/javascripts/spinnable.js
@@ -1,5 +1,5 @@
 // Show and hide spinners on Ajax requests.
 $(document).ready(function(){
   $('form.spinnable').on('ajax:before', function(evt, xhr, status){ $('#spinner').show();})
-  $('form.spinnable').on('ajax:after', function(evt, xhr, status){ $('#spinner').hide();})
+  $('form.spinnable').on('ajax:complete', function(evt, xhr, status){ $('#spinner').hide();})
 });

--- a/publify_core/app/views/admin/content/index.js.erb
+++ b/publify_core/app/views/admin/content/index.js.erb
@@ -1,2 +1,1 @@
 $("#articleList").html('<%= raw escape_javascript(render(partial: "article_list", locals: { articles: @articles })) %>');
-$("#spinner").show();


### PR DESCRIPTION
Problem: When I visit /admin/content and I type in the search bar, and I click "search" (or hit enter). A load spinner appears to the right of the button, and it does not go away.

What we did to fix: in the index.js.erb file we removed the unnecessary spinner.show / spinner.hide and fixed the ajax syntax to be ajax:complete
