### PR TITLE
Fixed for problem 2: Post tags shown as object

### DIFF
--- a/publify_core/app/assets/javascripts/publify_admin.js
+++ b/publify_core/app/assets/javascripts/publify_admin.js
@@ -76,7 +76,7 @@ function tag_manager() {
 }
 
 function save_article_tags() {
-  $('#article_keywords').val($('#article_form').find('input[name="hidden-article[keywords]"]'));
+  $('#article_keywords').val($('#article_form').find('input[name="hidden-article[keywords]"]').val());
 }
 
 function doneTyping () {


### PR DESCRIPTION
Problem 2:
  https://github.com/sf-wdi-40/publify-debugging-lab/issues/2

Root Cause:
  When saving the tags in save_article_tags(), the value saved into $('#article_keywords') element is:
$('#article_form').find('input[name="hidden-article[keywords]"]'
which is a jQuery object. It never fetches the actual value(tag names) from the object.

Solution:
Modifed the value to be saved into $('#article_keywords') 
  from:   $('#article_form').find('input[name="hidden-article[keywords]"]'
  to:       $('#article_form').find('input[name="hidden-article[keywords]"]').val()