### PR TITLE
Fixed problem 3: spinner not going away

### DIFF
--- a/publify_core/app/assets/javascripts/spinnable.js
+++ b/publify_core/app/assets/javascripts/spinnable.js
@@ -1,5 +1,5 @@
 // Show and hide spinners on Ajax requests.
 $(document).ready(function(){
   $('form.spinnable').on('ajax:before', function(evt, xhr, status){ $('#spinner').show();})
-  $('form.spinnable').on('ajax:after', function(evt, xhr, status){ $('#spinner').hide();})
+  $('form.spinnable').on('ajax:complete', function(evt, xhr, status){ $('#spinner').hide();})
 });


### PR DESCRIPTION
Fix for problem 3:
   https://github.com/sf-wdi-40/publify-debugging-lab/issues/3

Root Cause:
  Incorrect event name("after") used to set the condition for the spinner to go away. The proper event name is 'complete' instead of 'after'.

Solution:
  Change from 'after' to 'complete' event name used in JS when setting the event listener.