### PR TITLE
Fixed: sidebar styles issue #1

### DIFF
--- a/publify_core/app/views/archives_sidebar/_content.html.erb
+++ b/publify_core/app/views/archives_sidebar/_content.html.erb
@@ -1,6 +1,6 @@
 <% unless sidebar.archives.blank? %>
-  <h3 class="sidebar_title"><%= sidebar.title %></h3>
-  <div class="sidebar_body">
+  <h3 class="sidebar-title"><%= sidebar.title %></h3>
+  <div class="sidebar-body">
     <ul id="archives">
       <% sidebar.archives.each do |month| %>
         <% counter = sidebar.show_count ? "<em>(#{month[:article_count]})</em>" : "" %>


### PR DESCRIPTION
Issues/Request:

All titles in the sidebar should have monospace style font
All bullets should be unfilled circles.

Resolved:
All titles in the sidebar now have matching monospace style font
Bullets have been changed to unfilled circles.

Changes were made in the : publify_core/app/views/archives_sidebar/_content.html.erb