### PR TITLE
Fixed: spinner does not go away issue #3

### DIFF
--- a/publify_core/app/assets/javascripts/publify_admin.js
+++ b/publify_core/app/assets/javascripts/publify_admin.js
@@ -76,7 +76,7 @@ function tag_manager() {
 }
 
 function save_article_tags() {
-  $('#article_keywords').val($('#article_form').find('input[name="hidden-article[keywords]"]'));
+  $('#article_keywords').val($('#article_form').find('input[name="hidden-article[keywords]"]').val());
 }
 
 function doneTyping () {

--- a/publify_core/app/assets/javascripts/spinnable.js
+++ b/publify_core/app/assets/javascripts/spinnable.js
@@ -1,5 +1,5 @@
 // Show and hide spinners on Ajax requests.
 $(document).ready(function(){
   $('form.spinnable').on('ajax:before', function(evt, xhr, status){ $('#spinner').show();})
-  $('form.spinnable').on('ajax:after', function(evt, xhr, status){ $('#spinner').hide();})
+  $('form.spinnable').on('ajax:complete', function(evt, xhr, status){ $('#spinner').hide();})
 });

--- a/publify_core/app/views/archives_sidebar/_content.html.erb
+++ b/publify_core/app/views/archives_sidebar/_content.html.erb
@@ -1,6 +1,6 @@
 <% unless sidebar.archives.blank? %>
-  <h3 class="sidebar_title"><%= sidebar.title %></h3>
-  <div class="sidebar_body">
+  <h3 class="sidebar-title"><%= sidebar.title %></h3>
+  <div class="sidebar-body">
     <ul id="archives">
       <% sidebar.archives.each do |month| %>
         <% counter = sidebar.show_count ? "<em>(#{month[:article_count]})</em>" : "" %>


### PR DESCRIPTION
Issue/Request:
When visiting /admin/content and I type in the search bar, and I click "search" (or hit enter). A load spinner appears to the right of the button, and it does not go away.

Resolved:
When using the search bar the load spinner goes away upon completion of search.

Changes were made in: publify_core/app/assets/javascripts/spinnable.js