### PR TITLE
Fixed problem 4: Top month always empty

### DIFF
--- a/publify_core/app/models/archives_sidebar.rb
+++ b/publify_core/app/models/archives_sidebar.rb
@@ -30,7 +30,8 @@ class ArchivesSidebar < Sidebar
     article_counts = Content.find_by_sql(["select count(*) as count, #{date_func} from contents where type='Article' and published = ? and published_at < ? group by year,month order by year desc,month desc limit ? ", true, Time.now, count.to_i])
 
     @archives = article_counts.map do |entry|
-      month = (entry.month.to_i % 12) + 1
+      month = (entry.month.to_i % 12)
+      month = 12 if month == 0
       year = entry.year.to_i
       {
         name: I18n.l(Date.new(year, month), format: '%B %Y'),


### PR DESCRIPTION
Fixed problem https://github.com/sf-wdi-40/publify-debugging-lab/issues/4

Root Cause:
  Wrong calculation of the month before rendering.

Solution:
  Fixed the calculation