### PR TITLE
Fixed Issue2, Incorrect Tag Name

### DIFF
--- a/publify_core/app/assets/javascripts/publify_admin.js
+++ b/publify_core/app/assets/javascripts/publify_admin.js
@@ -76,7 +76,7 @@ function tag_manager() {
 }
 
 function save_article_tags() {
-  $('#article_keywords').val($('#article_form').find('input[name="hidden-article[keywords]"]'));
+  $('#article_keywords').val($('#article_form').find('input[name="hidden-article[keywords]"]').val());
 }
 
 function doneTyping () {


### PR DESCRIPTION
This address the issue #2, incorrect tag names were shown in newly created article.

I fixed by adding .val() to the end of the find function, which will return the value of the input instead of having them stored as the object that contains the value. 