### PR TITLE
Fixed issue_3, Spinner stays after search

### DIFF
--- a/publify_core/app/assets/javascripts/spinnable.js
+++ b/publify_core/app/assets/javascripts/spinnable.js
@@ -1,5 +1,5 @@
 // Show and hide spinners on Ajax requests.
 $(document).ready(function(){
   $('form.spinnable').on('ajax:before', function(evt, xhr, status){ $('#spinner').show();})
-  $('form.spinnable').on('ajax:after', function(evt, xhr, status){ $('#spinner').hide();})
+  $('form.spinnable').on('ajax:complete', function(evt, xhr, status){ $('#spinner').hide();})
 });

--- a/publify_core/app/views/admin/content/index.js.erb
+++ b/publify_core/app/views/admin/content/index.js.erb
@@ -1,2 +1,1 @@
 $("#articleList").html('<%= raw escape_javascript(render(partial: "article_list", locals: { articles: @articles })) %>');
-$("#spinner").show();


### PR DESCRIPTION
This address issue #3, spinner gif stays after user trigger search for article.

I fixed by ajax:"after" to ajax:"complete" so the hide() function will trigger after the ajax call is finished. I deleted the show function in another file so the spinner will not appear afterward. 